### PR TITLE
Fixed useUnMount hook

### DIFF
--- a/packages/core/useUnMount/index.ts
+++ b/packages/core/useUnMount/index.ts
@@ -10,6 +10,8 @@ import { useEffect } from 'react'
  */
 export function useUnMount(func: Fn) {
   useEffect(() => {
-    return func
+    return () => {
+      func()
+    }
   }, [func])
 }


### PR DESCRIPTION
Updated the useUnMount hook to correctly handle clean-up operations upon component unmounting. This version is now compatible with React 18's strict mode.

Reason for Changes:
The original useUnMount hook was not returning the correct cleanup function, which could lead to issues, especially in React 18's strict mode. I made adjustments to ensure that the cleanup function is returned correctly, making the hook compatible with strict mode.

Changes Made:
- Adjusted the useUnMount hook to correctly return the cleanup function.