### PR TITLE
fix: Could not find a declaration file for module

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,8 @@
   "exports": {
     ".": {
       "import": "./index.esm.js",
-      "require": "./index.cjs.js"
+      "require": "./index.cjs.js",
+      "types": "./index.d.ts"
     },
     "./*": "./*"
   },


### PR DESCRIPTION
Could not find a declaration file for module '@react-hooks-library/core'. 'node_modules/@react-hooks-library/core/index.esm.js' implicitly has an 'any' type.
  There are types at 'node_modules/@react-hooks-library/core/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@react-hooks-library/core' library may need to update its package.json or typings.