### PR TITLE
Fix: typo error in useMediaStream docs

### DIFF
--- a/packages/core/useMediaStream/docs.mdx
+++ b/packages/core/useMediaStream/docs.mdx
@@ -71,7 +71,7 @@ export function Demo() {
 
   The ref to attach the video element.
 
-- `stream` MediaStream)
+- `stream` (MediaStream)
 
   The stream object, wrapped in a react ref.
 


### PR DESCRIPTION
Add missing left parenthesis.