### PR TITLE
fix useKeyStroke using .includes regardless of the type of 'keys'

### DIFF
--- a/packages/core/useKeyStroke/index.ts
+++ b/packages/core/useKeyStroke/index.ts
@@ -64,7 +64,9 @@ export function useKeyStroke(
     (e: KeyboardEvent) => {
       const eventKey = code ? e.code : e.key
 
-      keys.includes(eventKey) && handler(e)
+      const matches =
+        typeof keys === 'string' ? keys === eventKey : keys.includes(eventKey)
+      if (matches) handler(e)
     },
     [code, handler, keys]
   )


### PR DESCRIPTION
Otherwise listening to just "Enter" would get triggered with "e" or "r"