### PR TITLE
fix useHasMounted docs links

### DIFF
--- a/packages/core/useHasMounted/docs.mdx
+++ b/packages/core/useHasMounted/docs.mdx
@@ -45,4 +45,4 @@ declare function useHasMounted(): boolean
 
 ## Source
 
-<Source name="useScroll" pkg="core" />
+<Source name="useHasMounted" pkg="core" />

--- a/website/ui/docs/Source.tsx
+++ b/website/ui/docs/Source.tsx
@@ -5,7 +5,7 @@ type Props = {
 
 export function Source({ name, pkg }: Props) {
   const baseUrl =
-    'https://github.com/react-hooks-library/react-hooks-library/blob/main/packages'
+    'https://github.com/heyitsarpit/react-hooks-library/blob/main/packages'
 
   const props = {
     target: '_blank',


### PR DESCRIPTION
## What changed

- Fixed the `useHasMounted` docs page so its Source/Demo/Docs links point to `useHasMounted` instead of `useScroll`.
- Updated the reusable docs `Source` component to link to `heyitsarpit/react-hooks-library`, matching the current repository.

## Why

Issue #30 reports that the `useHasMounted` source links navigate to the wrong hook page. The page had a copied `<Source name="useScroll" />` value, and the shared source-link base URL also referenced the old repository path.

Closes #30.