### PR TITLE
Support string breakpoint values

### DIFF
--- a/packages/core/BreakPointHooks/docs.mdx
+++ b/packages/core/BreakPointHooks/docs.mdx
@@ -13,6 +13,8 @@ import { Demo } from './demo.tsx'
 # BreakPointHooks
 
 Reactive hooks and utilities to be used with user provided breakpoints.
+Number values are treated as pixel widths. String values are passed through
+unchanged, so values like `48rem` or `1024px` can be used directly.
 
 ## Functions
 
@@ -80,6 +82,24 @@ function Demo() {
 
   // smaller than tablet
   const smaller = useSmaller('tablet')
+}
+```
+
+```tsx
+import { BreakPointHooks } from '@react-hooks-library/core'
+
+const breakpoints = {
+  sm: '40rem',
+  md: '48rem',
+  lg: '64rem',
+  xl: '80rem',
+  '2xl': '96rem'
+}
+
+const { useGreater } = BreakPointHooks(breakpoints)
+
+function Demo() {
+  const greater = useGreater('md')
 }
 ```
 
@@ -171,7 +191,9 @@ export const breakpointsSematic = {
  *
  * @see https://react-hooks-library.vercel.app/core/BreakPointHooks
  */
-declare function BreakPointHooks<BreakPoints extends Record<string, number>>(
+declare function BreakPointHooks<
+  BreakPoints extends Record<string, number | string>
+>(
   breakpoints: BreakPoints
 ): {
   /**

--- a/packages/core/BreakPointHooks/index.test.ts
+++ b/packages/core/BreakPointHooks/index.test.ts
@@ -1,0 +1,79 @@
+import { renderHook } from '@testing-library/react-hooks'
+import fs from 'fs/promises'
+import { join } from 'path'
+
+import { testDocs } from '../../../scripts/utils/testUtils'
+import { BreakPointHooks } from '.'
+
+const FunctionName = BreakPointHooks.name
+
+function mockMatchMedia() {
+  const matchMedia = jest.fn((query: string) => ({
+    matches: query.includes('48rem'),
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  }))
+
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: matchMedia
+  })
+
+  return matchMedia
+}
+
+describe(FunctionName, () => {
+  test('should be defined', () => {
+    expect(BreakPointHooks).toBeDefined()
+  })
+
+  test('should have docs with appropriate meta data', async () => {
+    const source = await fs.readFile(join(__dirname, '/docs.mdx'), 'utf-8')
+    testDocs(FunctionName, source)
+  })
+
+  test('should format numeric breakpoints as px', () => {
+    const matchMedia = mockMatchMedia()
+    const { isGreater, isSmaller, isInBetween } = BreakPointHooks({
+      sm: 640,
+      lg: 1024
+    })
+
+    isGreater('sm')
+    isSmaller('lg')
+    isInBetween('sm', 'lg')
+
+    expect(matchMedia).toHaveBeenNthCalledWith(1, '(min-width: 640px)')
+    expect(matchMedia).toHaveBeenNthCalledWith(2, '(max-width: 1024px)')
+    expect(matchMedia).toHaveBeenNthCalledWith(
+      3,
+      '(min-width: 640px) and (max-width: 1024px)'
+    )
+  })
+
+  test('should pass string breakpoints through unchanged', () => {
+    const matchMedia = mockMatchMedia()
+    const { isGreater, isSmaller, isInBetween, useGreater } = BreakPointHooks({
+      md: '48rem',
+      xl: '80rem'
+    })
+
+    expect(isGreater('md')).toBe(true)
+    isSmaller('xl')
+    isInBetween('md', 'xl')
+    renderHook(() => useGreater('md'))
+
+    expect(matchMedia).toHaveBeenNthCalledWith(1, '(min-width: 48rem)')
+    expect(matchMedia).toHaveBeenNthCalledWith(2, '(max-width: 80rem)')
+    expect(matchMedia).toHaveBeenNthCalledWith(
+      3,
+      '(min-width: 48rem) and (max-width: 80rem)'
+    )
+    expect(matchMedia).toHaveBeenCalledWith('(min-width: 48rem)')
+  })
+})

--- a/packages/core/BreakPointHooks/index.ts
+++ b/packages/core/BreakPointHooks/index.ts
@@ -2,10 +2,16 @@ import { useMediaQuery } from '../useMediaQuery'
 export * from './breakpoints'
 import { _window } from '../_ssr.config'
 
+type BreakPointValue = number | string
+
 function match(query: string): boolean {
   if (!_window) return false
 
   return _window.matchMedia(query).matches
+}
+
+function toWidth(value: BreakPointValue): string {
+  return typeof value === 'number' ? `${value}px` : value
 }
 
 /**
@@ -16,9 +22,9 @@ function match(query: string): boolean {
  *
  * @see https://react-hooks-library.vercel.app/core/BreakPointHooks
  */
-export function BreakPointHooks<BreakPoints extends Record<string, number>>(
-  breakpoints: BreakPoints
-) {
+export function BreakPointHooks<
+  BreakPoints extends Record<string, BreakPointValue>
+>(breakpoints: BreakPoints) {
   type BreakPointsKey = keyof BreakPoints
 
   return {
@@ -31,7 +37,7 @@ export function BreakPointHooks<BreakPoints extends Record<string, number>>(
      * @see https://react-hooks-library.vercel.app/core/BreakPointHooks
      **/
     useGreater: (k: BreakPointsKey) => {
-      return useMediaQuery(`(min-width: ${breakpoints[k]}px)`)
+      return useMediaQuery(`(min-width: ${toWidth(breakpoints[k])})`)
     },
 
     /**
@@ -45,7 +51,7 @@ export function BreakPointHooks<BreakPoints extends Record<string, number>>(
      * @see https://react-hooks-library.vercel.app/core/BreakPointHooks
      **/
     useSmaller: (k: BreakPointsKey) => {
-      return useMediaQuery(`(max-width: ${breakpoints[k]}px)`)
+      return useMediaQuery(`(max-width: ${toWidth(breakpoints[k])})`)
     },
 
     /**
@@ -60,7 +66,9 @@ export function BreakPointHooks<BreakPoints extends Record<string, number>>(
      **/
     useBetween: (a: BreakPointsKey, b: BreakPointsKey) => {
       return useMediaQuery(
-        `(min-width: ${breakpoints[a]}px) and (max-width: ${breakpoints[b]}px)`
+        `(min-width: ${toWidth(breakpoints[a])}) and (max-width: ${toWidth(
+          breakpoints[b]
+        )})`
       )
     },
 
@@ -72,7 +80,7 @@ export function BreakPointHooks<BreakPoints extends Record<string, number>>(
      * @see https://react-hooks-library.vercel.app/core/BreakPointHooks
      **/
     isGreater(k: BreakPointsKey) {
-      return match(`(min-width: ${breakpoints[k]}px)`)
+      return match(`(min-width: ${toWidth(breakpoints[k])})`)
     },
 
     /**
@@ -83,7 +91,7 @@ export function BreakPointHooks<BreakPoints extends Record<string, number>>(
      * @see https://react-hooks-library.vercel.app/core/BreakPointHooks
      **/
     isSmaller(k: BreakPointsKey) {
-      return match(`(max-width: ${breakpoints[k]}px)`)
+      return match(`(max-width: ${toWidth(breakpoints[k])})`)
     },
 
     /**
@@ -95,7 +103,9 @@ export function BreakPointHooks<BreakPoints extends Record<string, number>>(
      **/
     isInBetween(a: BreakPointsKey, b: BreakPointsKey) {
       return match(
-        `(min-width: ${breakpoints[a]}px) and (max-width: ${breakpoints[b]}px)`
+        `(min-width: ${toWidth(breakpoints[a])}) and (max-width: ${toWidth(
+          breakpoints[b]
+        )})`
       )
     }
   }


### PR DESCRIPTION
## Summary

- Allows `BreakPointHooks` to accept breakpoint values as either numbers or strings.
- Keeps existing numeric behavior by converting numbers to pixel values.
- Passes string values through unchanged for rem/px/custom unit breakpoints.
- Adds coverage for numeric and string breakpoint query generation.

Closes #36.