### PR TITLE
Document deprecated lifecycle hooks

### DIFF
--- a/packages/core/useEffectAfterMount/docs.mdx
+++ b/packages/core/useEffectAfterMount/docs.mdx
@@ -2,6 +2,7 @@
 category: lifecycle
 name: useEffectAfterMount
 description: A useEffect hook that does not run on mount, but only on subsequent updates
+deprecated: true
 ---
 
 import { Demo } from './demo.tsx'
@@ -13,6 +14,12 @@ import { Demo } from './demo.tsx'
 # useEffectAfterMount
 
 A useEffect hook that does not run on mount, but only on subsequent updates, useful for purely reactive effects.
+
+<Callout type="warning">
+  This hook is deprecated because it is not idempotent in React 18 Strict Mode.
+  Prefer using `useEffect` directly and making the effect safe to run more than
+  once.
+</Callout>
 
 The effect can return a cleanup function just like `useEffect`, that has the same semantics to the native `useEffect`.
 
@@ -53,6 +60,8 @@ export function Demo() {
 ```typescript
 /**
  * A useEffect hook does that not run on mount, but only on subsequent updates.
+ *
+ * @deprecated This hook breaks in React 18 Strict Mode, since it is not idempotent.
  *
  * @param effect
  * @param deps

--- a/packages/core/useMount/docs.mdx
+++ b/packages/core/useMount/docs.mdx
@@ -2,6 +2,7 @@
 category: lifecycle
 name: useMount
 description: Run a function when a component is mounted. 
+deprecated: true
 ---
 
 import { Demo } from './demo.tsx'
@@ -13,6 +14,11 @@ import { Demo } from './demo.tsx'
 # useMount
 
 Run a function when a component is mounted.
+
+<Callout type="warning">
+  This hook is deprecated because it is not idempotent in React 18 Strict Mode.
+  Prefer using `useEffect` directly.
+</Callout>
 
 ## Usage
 
@@ -34,6 +40,8 @@ function Demo() {
 ```typescript
 /**
  * Run a function when a component is mounted.
+ *
+ * @deprecated This hook breaks in React 18 Strict Mode, since it is not idempotent.
  *
  * @param callback function to be executed
  */

--- a/packages/core/useMountSync/docs.mdx
+++ b/packages/core/useMountSync/docs.mdx
@@ -2,6 +2,7 @@
 category: lifecycle
 name: useMountSync
 description: Run a function synchronously when a component is mounted but after DOM is painted. 
+deprecated: true
 ---
 
 import { Demo } from './demo.tsx'
@@ -14,6 +15,11 @@ import { Demo } from './demo.tsx'
 
 Run a function synchronously when a component is mounted and after DOM is painted.
 Useful when accessing the DOM or creating event listeners.
+
+<Callout type="warning">
+  This hook is deprecated because it is not idempotent in React 18 Strict Mode.
+  Prefer using `useLayoutEffect` directly.
+</Callout>
 
 ## Usage
 
@@ -35,6 +41,8 @@ function Demo() {
 ```typescript
 /**
  * Run a function synchronously when a component is mounted and after DOM is painted.
+ *
+ * @deprecated This hook breaks in React 18 Strict Mode, since it is not idempotent.
  *
  * @param callback function to be executed
  */

--- a/packages/core/useUnMount/docs.mdx
+++ b/packages/core/useUnMount/docs.mdx
@@ -2,11 +2,17 @@
 category: lifecycle
 name: useUnMount
 description: Run a function when component is unmounted.
+deprecated: true
 ---
 
 # useUnMount
 
 Run a function when component is unmounted.
+
+<Callout type="warning">
+  This hook is deprecated because it is not idempotent in React 18 Strict Mode.
+  Prefer returning a cleanup function from `useEffect` directly.
+</Callout>
 
 ## Usage
 
@@ -27,6 +33,8 @@ function Demo() {
 ```typescript
 /**
  * Run a function when component is unmounted.
+ *
+ * @deprecated This hook breaks in React 18 Strict Mode, since it is not idempotent.
  *
  * @param callback function to be executed
  */


### PR DESCRIPTION
## Summary

- Adds visible deprecation notices to lifecycle hooks that are not idempotent under React 18 Strict Mode.
- Marks the affected docs frontmatter as deprecated.
- Updates rendered type declaration snippets with `@deprecated` notes.

Closes #25.