### PR TITLE
Fix useKeyStroke string matching

### DIFF
--- a/packages/core/useKeyStroke/index.test.ts
+++ b/packages/core/useKeyStroke/index.test.ts
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react-hooks'
+import fs from 'fs/promises'
+import { join } from 'path'
+
+import { testDocs } from '../../../scripts/utils/testUtils'
+import { useKeyDown, useKeyStroke, useKeyUp } from '.'
+
+const FunctionName = useKeyStroke.name
+
+function dispatchKeyboardEvent(eventName: string, init: KeyboardEventInit) {
+  window.dispatchEvent(new KeyboardEvent(eventName, init))
+}
+
+describe(FunctionName, () => {
+  test('should be defined', () => {
+    expect(useKeyStroke).toBeDefined()
+  })
+
+  test('should have docs with appropriate meta data', async () => {
+    const source = await fs.readFile(join(__dirname, '/docs.mdx'), 'utf-8')
+    testDocs(FunctionName, source)
+  })
+
+  test('should match string keys exactly', () => {
+    const handler = jest.fn()
+
+    renderHook(() => useKeyDown('Enter', handler))
+
+    dispatchKeyboardEvent('keydown', { key: 'r' })
+    dispatchKeyboardEvent('keydown', { key: 'Enter' })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  test('should match keys from an array', () => {
+    const handler = jest.fn()
+
+    renderHook(() => useKeyDown(['w', 'W', 'ArrowUp'], handler))
+
+    dispatchKeyboardEvent('keydown', { key: 's' })
+    dispatchKeyboardEvent('keydown', { key: 'ArrowUp' })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  test('should match event code when code option is true', () => {
+    const handler = jest.fn()
+
+    renderHook(() => useKeyDown('Digit1', handler, { code: true }))
+
+    dispatchKeyboardEvent('keydown', { key: '1', code: 'KeyA' })
+    dispatchKeyboardEvent('keydown', { key: '1', code: 'Digit1' })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  test('should listen to the configured event name', () => {
+    const handler = jest.fn()
+
+    renderHook(() => useKeyUp('Escape', handler))
+
+    dispatchKeyboardEvent('keydown', { key: 'Escape' })
+    dispatchKeyboardEvent('keyup', { key: 'Escape' })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/useKeyStroke/index.ts
+++ b/packages/core/useKeyStroke/index.ts
@@ -64,7 +64,10 @@ export function useKeyStroke(
     (e: KeyboardEvent) => {
       const eventKey = code ? e.code : e.key
 
-      keys.includes(eventKey) && handler(e)
+      const matches =
+        typeof keys === 'string' ? keys === eventKey : keys.includes(eventKey)
+
+      if (matches) handler(e)
     },
     [code, handler, keys]
   )


### PR DESCRIPTION
## Summary

- Matches single string keys with exact equality instead of substring matching.
- Keeps array key matching with `includes`.
- Adds regression coverage for string keys, array keys, `code: true`, and keyup listeners.

Recovered from the bug fix originally proposed by @AlexMenor in #34.